### PR TITLE
Feature/add can support

### DIFF
--- a/ssc_interface_wrapper/CMakeLists.txt
+++ b/ssc_interface_wrapper/CMakeLists.txt
@@ -12,7 +12,10 @@ find_package(catkin REQUIRED COMPONENTS
   cav_msgs
   cav_srvs
   autoware_msgs
+  can_msgs  
   std_msgs
+  pacmod_msgs
+  j2735_msgs
   roscpp
 )
 

--- a/ssc_interface_wrapper/include/ssc_interface_wrapper_worker.h
+++ b/ssc_interface_wrapper/include/ssc_interface_wrapper_worker.h
@@ -18,25 +18,30 @@
 
 #include <cav_msgs/DriverStatus.h>
 #include <cav_msgs/RobotEnabled.h>
-#include <autoware_msgs/VehicleStatus.h>
+#include <pacmod_msgs/SystemRptInt.h>
+#include <pacmod_msgs/GlobalRpt.h>
+#include <j2735_msgs/TransmissionState.h>
 
 class SSCInterfaceWrapperWorker
 {
 
 public:
 
-    SSCInterfaceWrapperWorker() : robotic_control_engaged_(false) {}
+    SSCInterfaceWrapperWorker() : robotic_control_engaged_(false), can_bus_timeout_(false), pacmod_fault_(false) {}
     ~SSCInterfaceWrapperWorker() {}
 
     bool is_engaged();
     uint8_t get_driver_status(const ros::Time& current_time, double timeout);
-    void on_new_status_msg(const autoware_msgs::VehicleStatusConstPtr& msg, const ros::Time& current_time);
+    void on_new_status_msg(const pacmod_msgs::GlobalRptConstPtr& msg, const ros::Time& current_time);
+    int convert_shift_state_to_J2735(const pacmod_msgs::SystemRptIntConstPtr shift_state);
 
 private:
     
     bool robotic_control_engaged_;
+    bool can_bus_timeout_;
+    bool pacmod_fault_;
     ros::Time last_vehicle_status_time_;
     
-    void update_control_status(const autoware_msgs::VehicleStatusConstPtr& msg);
+    void update_control_status(const pacmod_msgs::GlobalRptConstPtr& msg);
 
 };

--- a/ssc_interface_wrapper/launch/ssc_interface_wrapper.launch
+++ b/ssc_interface_wrapper/launch/ssc_interface_wrapper.launch
@@ -20,4 +20,6 @@
     <node name="ssc_interface_wrapper" pkg="ssc_interface_wrapper" type="ssc_interface_wrapper_node"/>
     <rosparam command="load" file="$(find ssc_interface_wrapper)/config/parameters.yaml"/>
     <node pkg="topic_tools" type="relay" name="relay_vehicle_command" args="/controller/vehicle_commands /vehicle_cmd"/>
+    <node pkg="topic_tools" type="relay" name="relay_wheel_speed" args="/can/wheel_speed /parsed_tx/wheel_speed_rpt"/>
+
 </launch>

--- a/ssc_interface_wrapper/package.xml
+++ b/ssc_interface_wrapper/package.xml
@@ -8,8 +8,11 @@
   <author email="carma@todo.todo">carma</author>
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>
+  <depend>pacmod_msgs</depend>
+  <depend>can_msgs</depend>
   <depend>cav_driver_utils</depend>
   <depend>cav_msgs</depend>
+  <depend>j2735_msgs</depend>
   <depend>cav_srvs</depend>
   <depend>autoware_msgs</depend>
 </package>

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
@@ -27,20 +27,20 @@ void SSCInterfaceWrapper::initialize() {
     status_.can = true;
 
     // Initialize all subscribers
-    pacmod_rpt_sub_ = nh_->subscribe("/parsed_tx/global_rpt", 5, &SSCInterfaceWrapper::pacmod_rpt_cb, this);
-    steer_sub_ = nh_->subscribe("/parsed_tx/steer_rpt", 5, &SSCInterfaceWrapper::steer_cb, this);
-    brake_sub_ = nh_->subscribe("/parsed_tx/brake_aux_rpt", 5, &SSCInterfaceWrapper::brake_cb, this);
-    shift_sub_ = nh_->subscribe("/parsed_tx/shift_aux_rpt", 5, &SSCInterfaceWrapper::shift_cb, this);
+    pacmod_rpt_sub_ = nh_->subscribe("parsed_tx/global_rpt", 5, &SSCInterfaceWrapper::pacmod_rpt_cb, this);
+    steer_sub_ = nh_->subscribe("parsed_tx/steer_rpt", 5, &SSCInterfaceWrapper::steer_cb, this);
+    brake_sub_ = nh_->subscribe("parsed_tx/brake_aux_rpt", 5, &SSCInterfaceWrapper::brake_cb, this);
+    shift_sub_ = nh_->subscribe("parsed_tx/shift_aux_rpt", 5, &SSCInterfaceWrapper::shift_cb, this);
 
     // Initialize all publishers
-    steering_wheel_angle_pub_ = nh_->advertise<std_msgs::Float64>("/can/steering_wheel_angle", 1);
-    brake_position_pub_ = nh_->advertise<std_msgs::Float64>("/can/brake_position", 1);
-    transmission_pub_ = nh_->advertise<j2735_msgs::TransmissionState>("/can/transmission_state", 1);
-    robot_status_pub_   = nh_->advertise<cav_msgs::RobotEnabled>("/controller/robot_status", 1);
+    steering_wheel_angle_pub_ = nh_->advertise<std_msgs::Float64>("can/steering_wheel_angle", 1);
+    brake_position_pub_ = nh_->advertise<std_msgs::Float64>("can/brake_position", 1);
+    transmission_pub_ = nh_->advertise<j2735_msgs::TransmissionState>("can/transmission_state", 1);
+    robot_status_pub_   = nh_->advertise<cav_msgs::RobotEnabled>("controller/robot_status", 1);
     vehicle_engage_pub_ = nh_->advertise<std_msgs::Bool>("/vehicle/engage", 5);
     
     // initialize services
-    enable_robotic_control_srv_ = nh_->advertiseService("/controller/enable_robotic", &SSCInterfaceWrapper::enable_robotic_control_cb, this);
+    enable_robotic_control_srv_ = nh_->advertiseService("controller/enable_robotic", &SSCInterfaceWrapper::enable_robotic_control_cb, this);
 
     // Load parameters
     private_nh_->param<double>("controller_timeout", controller_timeout_, 1);

--- a/ssc_interface_wrapper/test/test_ssc_interface_wrapper.cpp
+++ b/ssc_interface_wrapper/test/test_ssc_interface_wrapper.cpp
@@ -21,49 +21,22 @@ TEST(SSCInterfaceWrapperWorkerTest, testControlStatusChangeOne)
 {
     SSCInterfaceWrapperWorker worker;
     EXPECT_EQ(false, worker.is_engaged());
-    autoware_msgs::VehicleStatus msg;
-    msg.drivemode = autoware_msgs::VehicleStatus::MODE_AUTO;
-    msg.steeringmode = autoware_msgs::VehicleStatus::MODE_AUTO;
-    autoware_msgs::VehicleStatusConstPtr status_msg(new autoware_msgs::VehicleStatus(msg));
+    pacmod_msgs::GlobalRpt msg;
+    msg.enabled = true;
+    pacmod_msgs::GlobalRptConstPtr status_msg(new pacmod_msgs::GlobalRpt(msg));
     ros::Time current_time(10, 10);
     worker.on_new_status_msg(status_msg, current_time);
     EXPECT_EQ(true, worker.is_engaged());
 }
+
 
 TEST(SSCInterfaceWrapperWorkerTest, testControlStatusChangeTwo)
 {
     SSCInterfaceWrapperWorker worker;
     EXPECT_EQ(false, worker.is_engaged());
-    autoware_msgs::VehicleStatus msg;
-    msg.drivemode = autoware_msgs::VehicleStatus::MODE_AUTO;
-    msg.steeringmode = autoware_msgs::VehicleStatus::MODE_MANUAL;
-    autoware_msgs::VehicleStatusConstPtr status_msg(new autoware_msgs::VehicleStatus(msg));
-    ros::Time current_time(10, 10);
-    worker.on_new_status_msg(status_msg, current_time);
-    EXPECT_EQ(true, worker.is_engaged());
-}
-
-TEST(SSCInterfaceWrapperWorkerTest, testControlStatusChangeThree)
-{
-    SSCInterfaceWrapperWorker worker;
-    EXPECT_EQ(false, worker.is_engaged());
-    autoware_msgs::VehicleStatus msg;
-    msg.drivemode = autoware_msgs::VehicleStatus::MODE_MANUAL;
-    msg.steeringmode = autoware_msgs::VehicleStatus::MODE_AUTO;
-    autoware_msgs::VehicleStatusConstPtr status_msg(new autoware_msgs::VehicleStatus(msg));
-    ros::Time current_time(10, 10);
-    worker.on_new_status_msg(status_msg, current_time);
-    EXPECT_EQ(true, worker.is_engaged());
-}
-
-TEST(SSCInterfaceWrapperWorkerTest, testControlStatusChangeFour)
-{
-    SSCInterfaceWrapperWorker worker;
-    EXPECT_EQ(false, worker.is_engaged());
-    autoware_msgs::VehicleStatus msg;
-    msg.drivemode = autoware_msgs::VehicleStatus::MODE_MANUAL;
-    msg.steeringmode = autoware_msgs::VehicleStatus::MODE_MANUAL;
-    autoware_msgs::VehicleStatusConstPtr status_msg(new autoware_msgs::VehicleStatus(msg));
+    pacmod_msgs::GlobalRpt msg;
+    msg.enabled = false;
+    pacmod_msgs::GlobalRptConstPtr status_msg(new pacmod_msgs::GlobalRpt(msg));
     ros::Time current_time(10, 10);
     worker.on_new_status_msg(status_msg, current_time);
     EXPECT_EQ(false, worker.is_engaged());
@@ -80,10 +53,10 @@ TEST(SSCInterfaceWrapperWorkerTest, testGetDriverStatusOne)
 TEST(SSCInterfaceWrapperWorkerTest, testGetDriverStatusTwo)
 {
     SSCInterfaceWrapperWorker worker;
-    autoware_msgs::VehicleStatus msg;
+    pacmod_msgs::GlobalRpt msg;
     msg.header.stamp.sec = 10;
     msg.header.stamp.nsec = 10;
-    autoware_msgs::VehicleStatusConstPtr status_msg(new autoware_msgs::VehicleStatus(msg));
+    pacmod_msgs::GlobalRptConstPtr status_msg(new pacmod_msgs::GlobalRpt(msg));
     ros::Time current_time1(10, 20);
     worker.on_new_status_msg(status_msg, current_time1);
     ros::Time current_time2(11, 20);
@@ -94,13 +67,41 @@ TEST(SSCInterfaceWrapperWorkerTest, testGetDriverStatusTwo)
 TEST(SSCInterfaceWrapperWorkerTest, testGetDriverStatusThree)
 {
     SSCInterfaceWrapperWorker worker;
-    autoware_msgs::VehicleStatus msg;
+    pacmod_msgs::GlobalRpt msg;
     msg.header.stamp.sec = 10;
     msg.header.stamp.nsec = 10;
-    autoware_msgs::VehicleStatusConstPtr status_msg(new autoware_msgs::VehicleStatus(msg));
+    pacmod_msgs::GlobalRptConstPtr status_msg(new pacmod_msgs::GlobalRpt(msg));
     ros::Time current_time1(10, 20);
     worker.on_new_status_msg(status_msg, current_time1);
     ros::Time current_time2(12, 30);
+    EXPECT_EQ(cav_msgs::DriverStatus::FAULT, worker.get_driver_status(current_time2, 2));
+}
+
+TEST(SSCInterfaceWrapperWorkerTest, testGetDriverStatusFour)
+{
+    SSCInterfaceWrapperWorker worker;
+    pacmod_msgs::GlobalRpt msg;
+    msg.header.stamp.sec = 10;
+    msg.header.stamp.nsec = 10;
+    msg.fault_active = true;
+    pacmod_msgs::GlobalRptConstPtr status_msg(new pacmod_msgs::GlobalRpt(msg));
+    ros::Time current_time1(10, 20);
+    worker.on_new_status_msg(status_msg, current_time1);
+    ros::Time current_time2(11, 20);
+    EXPECT_EQ(cav_msgs::DriverStatus::FAULT, worker.get_driver_status(current_time2, 2));
+}
+
+TEST(SSCInterfaceWrapperWorkerTest, testGetDriverStatusFive)
+{
+    SSCInterfaceWrapperWorker worker;
+    pacmod_msgs::GlobalRpt msg;
+    msg.header.stamp.sec = 10;
+    msg.header.stamp.nsec = 10;
+    msg.vehicle_can_timeout = true;
+    pacmod_msgs::GlobalRptConstPtr status_msg(new pacmod_msgs::GlobalRpt(msg));
+    ros::Time current_time1(10, 20);
+    worker.on_new_status_msg(status_msg, current_time1);
+    ros::Time current_time2(11, 20);
     EXPECT_EQ(cav_msgs::DriverStatus::FAULT, worker.get_driver_status(current_time2, 2));
 }
 


### PR DESCRIPTION
Two major changes:
1. Use global report from pacmod driver to determine the health status of the controller device.
2. Add CAN support to include CAN messages that pacmod provided.