### PR TITLE
Fix/pac mod ssc remappings

### DIFF
--- a/ssc_interface_wrapper/launch/ssc_pacmod_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_pacmod_driver.launch
@@ -25,8 +25,13 @@
   <arg name="kvaser_circuit_id" default="0" />
 
   <!-- Launch Wrapper -->
-  <include file="$(find ssc_interface_wrapper)/launch/ssc_interface_wrapper.launch"/>
-
+  <group> <!-- Group to scope remappings -->
+    <remap from="parsed_tx/global_rpt" to="pacmod/parsed_tx/global_rpt"/>
+    <remap from="parsed_tx/steer_rpt" to="pacmod/parsed_tx/steer_rpt"/>
+    <remap from="parsed_tx/brake_aux_rpt" to="pacmod/parsed_tx/brake_aux_rpt"/>
+    <remap from="parsed_tx/shift_aux_rpt" to="pacmod/parsed_tx/shift_aux_rpt"/>
+    <include file="$(find ssc_interface_wrapper)/launch/ssc_interface_wrapper.launch"/>
+  </group>
   <!-- Launch Wrapped Nodes -->
   <!-- Drive By Wire -->
   <include file="$(find pacmod3)/launch/pacmod3.launch" ns="pacmod">

--- a/ssc_interface_wrapper/launch/ssc_pacmod_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_pacmod_driver.launch
@@ -28,8 +28,8 @@
   <group> <!-- Group to scope remappings -->
     <remap from="parsed_tx/global_rpt" to="pacmod/parsed_tx/global_rpt"/>
     <remap from="parsed_tx/steer_rpt" to="pacmod/parsed_tx/steer_rpt"/>
-    <remap from="parsed_tx/brake_aux_rpt" to="pacmod/parsed_tx/brake_aux_rpt"/>
-    <remap from="parsed_tx/shift_aux_rpt" to="pacmod/parsed_tx/shift_aux_rpt"/>
+    <remap from="parsed_tx/brake_rpt" to="pacmod/parsed_tx/brake_rpt"/>
+    <remap from="parsed_tx/shift_rpt" to="pacmod/parsed_tx/shift_rpt"/>
     <include file="$(find ssc_interface_wrapper)/launch/ssc_interface_wrapper.launch"/>
   </group>
   <!-- Launch Wrapped Nodes -->

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
@@ -29,8 +29,8 @@ void SSCInterfaceWrapper::initialize() {
     // Initialize all subscribers
     pacmod_rpt_sub_ = nh_->subscribe("parsed_tx/global_rpt", 5, &SSCInterfaceWrapper::pacmod_rpt_cb, this);
     steer_sub_ = nh_->subscribe("parsed_tx/steer_rpt", 5, &SSCInterfaceWrapper::steer_cb, this);
-    brake_sub_ = nh_->subscribe("parsed_tx/brake_aux_rpt", 5, &SSCInterfaceWrapper::brake_cb, this);
-    shift_sub_ = nh_->subscribe("parsed_tx/shift_aux_rpt", 5, &SSCInterfaceWrapper::shift_cb, this);
+    brake_sub_ = nh_->subscribe("parsed_tx/brake_rpt", 5, &SSCInterfaceWrapper::brake_cb, this);
+    shift_sub_ = nh_->subscribe("parsed_tx/shift_rpt", 5, &SSCInterfaceWrapper::shift_cb, this);
 
     // Initialize all publishers
     steering_wheel_angle_pub_ = nh_->advertise<std_msgs::Float64>("can/steering_wheel_angle", 1);


### PR DESCRIPTION
This PR corrects some mismatched topic names in the driver wrapper and updates the launch file to have correct topic re-mappings for the pacmod.