### PR TITLE
Feature/remove pacmod dependency for controller wrapper

### DIFF
--- a/ssc_interface_wrapper/launch/carma_pacifica_speed_steering_control.launch
+++ b/ssc_interface_wrapper/launch/carma_pacifica_speed_steering_control.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<launch>
+
+  <arg name="speed_model_json" default="$(find ssc_ne_pacifica)/json/speed_model.json" />
+  <arg name="steering_model_json" default="$(find ssc_ne_pacifica)/json/steering_model.json" />
+  <arg name="veh_controller_json" default="$(find ssc_ne_pacifica)/json/veh_controller.json" />
+  <arg name="veh_interface_json" default="$(find ssc_ne_pacifica)/json/veh_interface.json" />
+
+  <group>
+    <node pkg="ssc_ne_pacifica" type="speed_model" name="speed_model" args="-f $(arg speed_model_json)" />
+    <node pkg="ssc_ne_pacifica" type="steering_model" name="steering_model" args="-f $(arg steering_model_json)" />
+    <node pkg="ssc_ne_pacifica" type="veh_controller" name="veh_controller" args="-f $(arg veh_controller_json)" />
+
+    <node pkg="ssc_ne_pacifica" type="veh_interface" name="veh_interface" args="-f $(arg veh_interface_json)" />
+  </group>
+</launch>

--- a/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
@@ -68,7 +68,6 @@
     <remap from="as/turn_signal_command" to="turn_signal_command"/>
     <remap from="as/velocity_accel" to="velocity_accel"/>
     <include file="$(find as)/launch/ssc_interface.launch">
-        <arg name="use_rear_wheel_speed" value="true"/>
         <arg name="use_adaptive_gear_ratio" value="true"/>
         <arg name="command_timeout" value="1000"/>
         <arg name="loop_rate" value="30.0"/>

--- a/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
@@ -67,6 +67,8 @@
     <remap from="as/throttle_feedback" to="throttle_feedback"/>
     <remap from="as/turn_signal_command" to="turn_signal_command"/>
     <remap from="as/velocity_accel" to="velocity_accel"/>
+    <remap from="as/steering_feedback" to="steering_feedback"/>
+    <remap from="as/velocity_accel_cov" to="velocity_accel_cov"/>
     <include file="$(find as)/launch/ssc_interface.launch">
         <arg name="use_adaptive_gear_ratio" value="true"/>
         <arg name="command_timeout" value="1000"/>

--- a/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_ne_pacifica_driver.launch
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!--
+  Copyright (C) 2018-2019 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
+<!--
+	This file is used to launch a CARMA compatible controller driver for the pacmod using the ssc interface
+-->
+<launch>
+
+  <arg name="can_hardware_id" default="57755" />
+  <arg name="can_circuit_id" default="0" />
+  <arg name="can_bit_rate" default="500000" />
+
+  <!-- Launch Wrapper -->
+  <group> <!-- Group to scope remappings -->
+    <include file="$(find ssc_interface_wrapper)/launch/ssc_interface_wrapper.launch"/>
+  </group>
+  <!-- Launch Wrapped Nodes -->
+  <!-- Drive By Wire -->
+  <include file="$(find dbw_pacifica_can)/launch/dbw.launch">
+    <arg name="can_hardware_id" default="57755" />
+    <arg name="can_circuit_id" default="0" />
+    <arg name="can_bit_rate" default="500000" />
+  </include>
+
+  <!-- SSC -->
+  <group>
+    <!--<remap from="brake_cmd" to="ne_pacifica/brake_cmd"/>
+    <remap from="brake_report" to="ne_pacifica/brake_report"/>
+    <remap from="steering_cmd" to="ne_pacifica/steering_cmd"/>
+    <remap from="steering_report" to="ne_pacifica/steering_report"/>
+    <remap from="accelerator_pedal_cmd" to="ne_pacifica/accelerator_pedal_cmd"/>
+    <remap from="accelerator_pedal_report" to="ne_pacifica/accelerator_pedal_report"/>
+    <remap from="gear_cmd" to="ne_pacifica/gear_cmd"/>
+    <remap from="gear_report" to="ne_pacifica/gear_report"/>
+    <remap from="misc_cmd" to="ne_pacifica/misc_cmd"/>
+    <remap from="driver_input_report" to="ne_pacifica/driver_input_report"/>
+    <remap from="wheel_speed_report" to="ne_pacifica/wheel_speed_report"/>
+    <remap from="global_report" to="ne_pacifica/dbw_enabled"/>
+    <remap from="enable" to="ne_pacifica/enable"/>
+    <remap from="disable" to="ne_pacifica/disable"/>
+    <remap from="global_enable_cmd" to="ne_pacifica/global_enable_cmd"/>-->
+    <include file="$(find ssc_interface_wrapper)/launch/carma_pacifica_speed_steering_control.launch"/>
+  </group>
+
+  <!-- SSC Interface -->
+  <group>
+    <remap from="as/arbitrated_speed_commands" to="arbitrated_speed_commands"/>
+    <remap from="as/arbitrated_steering_commands" to="arbitrated_steering_commands"/>
+    <remap from="as/brake_feedback" to="brake_feedback"/>
+    <remap from="as/curvature_feedback" to="curvature_feedback"/>
+    <remap from="as/gear_feedback" to="gear_feedback"/>
+    <remap from="as/gear_select" to="gear_select"/>
+    <remap from="as/module_states" to="module_states"/>
+    <remap from="as/throttle_feedback" to="throttle_feedback"/>
+    <remap from="as/turn_signal_command" to="turn_signal_command"/>
+    <remap from="as/velocity_accel" to="velocity_accel"/>
+    <include file="$(find as)/launch/ssc_interface.launch">
+        <arg name="use_rear_wheel_speed" value="true"/>
+        <arg name="use_adaptive_gear_ratio" value="true"/>
+        <arg name="command_timeout" value="1000"/>
+        <arg name="loop_rate" value="30.0"/>
+        <arg name="wheel_base" value="2.79"/>
+        <arg name="tire_radius" value="0.39"/>
+        <arg name="acceleration_limit" value="3.0"/>
+        <arg name="deceleration_limit" value="6.0"/>
+        <arg name="max_curvature_rate" value="0.75"/>
+    </include>
+  </group>
+</launch>

--- a/ssc_interface_wrapper/launch/ssc_pacmod_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_pacmod_driver.launch
@@ -72,7 +72,6 @@
     <remap from="as/turn_signal_command" to="turn_signal_command"/>
     <remap from="as/velocity_accel" to="velocity_accel"/>
     <include file="$(find as)/launch/ssc_interface.launch">
-        <arg name="use_rear_wheel_speed" value="true"/>
         <arg name="use_adaptive_gear_ratio" value="true"/>
         <arg name="command_timeout" value="1000"/>
         <arg name="loop_rate" value="30.0"/>

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper.cpp
@@ -27,7 +27,7 @@ void SSCInterfaceWrapper::initialize() {
     status_.can = true;
 
     // Initialize all subscribers
-    ssc_state_sub_ = nh_->subscribe("module_state", 5, &SSCInterfaceWrapper::ssc_state_cb, this);
+    ssc_state_sub_ = nh_->subscribe("module_states", 5, &SSCInterfaceWrapper::ssc_state_cb, this);
     steer_sub_ = nh_->subscribe("parsed_tx/steer_rpt", 5, &SSCInterfaceWrapper::steer_cb, this);
     brake_sub_ = nh_->subscribe("parsed_tx/brake_rpt", 5, &SSCInterfaceWrapper::brake_cb, this);
     shift_sub_ = nh_->subscribe("parsed_tx/shift_rpt", 5, &SSCInterfaceWrapper::shift_cb, this);

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
@@ -30,7 +30,10 @@ uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_ti
 
 void SSCInterfaceWrapperWorker::on_new_status_msg(const automotive_navigation_msgs::ModuleStateConstPtr& msg, const ros::Time& current_time)
 {
-    if(msg->name.compare("/veh_controller") == 0)
+	const std::string controller_tag("veh_controller");
+	
+    if(msg->name.length() >= controller_tag.length() 
+		&& (0 == msg->name.compare (msg->name.length() - controller_tag.length(), controller_tag.length(), controller_tag)))
 	{
         last_vehicle_status_time_ = current_time;
 		update_control_status(msg);


### PR DESCRIPTION
Updates the pacifica SSC interface. Adds launch files used for the new eagle ssc and updates the status check to use the end of the controller name so that namespaces are supported. 