### PR TITLE
Fix high rate on vehicle twist

### DIFF
--- a/ssc_interface_wrapper/launch/ssc_ds_fusion_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_ds_fusion_driver.launch
@@ -64,6 +64,7 @@
     <node pkg="dbw_mkz_can" type="dbw_node" name="dbw_node" output="screen">
       <remap from="can_rx" to="$(arg can_ns)/can_rx"/>
       <remap from="can_tx" to="$(arg can_ns)/can_tx"/>
+      <remap from="twist" to="dbw_node_twist"/>
       <param name="frame_id" value="$(arg frame_id)" />
       <param name="warn_cmds" value="$(arg warn_cmds)" />
       <param name="pedal_luts" value="$(arg pedal_luts)" />


### PR DESCRIPTION
On Ford Fusion, ```/hardware_interface/vehicle/twist``` topic has 120 Hz publication rate because both dbw_node and ssc_interface publish on this topic. Thus, this topic contains two frame id, one is "base_link" from ssc_interface and the other one is "footprint_base" from dbw_node. Remap dbw_node twist to another topic name since it does not suppose to be used by any other node in the CARMA/Autoware system. 