### PR TITLE
Feature/reengage capability

### DIFF
--- a/ssc_interface_wrapper/include/ssc_interface_wrapper.h
+++ b/ssc_interface_wrapper/include/ssc_interface_wrapper.h
@@ -61,6 +61,9 @@ private:
     // ROS parameter for determining controller timeout
     double controller_timeout_;
 
+    // bool flag indicates the wrapper is in the reengage mode
+    bool reengage_state_;
+
     // robotic status message as a local variable
     cav_msgs::RobotEnabled robotic_status_msg_;
 
@@ -78,6 +81,9 @@ private:
 
     // check controller health status
     void update_controller_health_status();
+
+    // reengage robotic control if the reengage_state_ flag is set
+    void reengage_robotic_control();
 
     // cav::DriverWrapper members
     virtual void initialize();

--- a/ssc_interface_wrapper/include/ssc_interface_wrapper_worker.h
+++ b/ssc_interface_wrapper/include/ssc_interface_wrapper_worker.h
@@ -18,6 +18,7 @@
 
 #include <cav_msgs/DriverStatus.h>
 #include <cav_msgs/RobotEnabled.h>
+#include <cav_srvs/SetEnableRobotic.h>
 #include <pacmod_msgs/SystemRptInt.h>
 #include <automotive_navigation_msgs/ModuleState.h>
 #include <j2735_msgs/TransmissionState.h>
@@ -27,21 +28,18 @@ class SSCInterfaceWrapperWorker
 
 public:
 
-    SSCInterfaceWrapperWorker() : robotic_control_engaged_(false), can_bus_timeout_(false), controller_fault_(false) {}
+    SSCInterfaceWrapperWorker() : latest_ssc_status_("not_ready") {}
     ~SSCInterfaceWrapperWorker() {}
 
     bool is_engaged();
     uint8_t get_driver_status(const ros::Time& current_time, double timeout);
     void on_new_status_msg(const automotive_navigation_msgs::ModuleStateConstPtr& msg, const ros::Time& current_time);
     int convert_shift_state_to_J2735(const pacmod_msgs::SystemRptIntConstPtr shift_state);
+    std::string get_current_ssc_state();
 
 private:
     
-    bool robotic_control_engaged_;
-    bool can_bus_timeout_;
-    bool controller_fault_;
+    std::string latest_ssc_status_;
     ros::Time last_vehicle_status_time_;
-    
-    void update_control_status(const automotive_navigation_msgs::ModuleStateConstPtr& msg);
 
 };

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
@@ -18,11 +18,11 @@
 
 uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_time, double timeout)
 {
-    if(last_vehicle_status_time_.isZero())
+    if(last_vehicle_status_time_.isZero() || latest_ssc_status_.compare("not_ready") == 0)
     {
         return cav_msgs::DriverStatus::OFF;
     }
-    else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || !latest_ssc_status_.compare("fatal")) {
+    else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || latest_ssc_status_.compare("fatal") == 0) {
         return cav_msgs::DriverStatus::FAULT;
     }
     return cav_msgs::DriverStatus::OPERATIONAL;
@@ -31,10 +31,11 @@ uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_ti
 void SSCInterfaceWrapperWorker::on_new_status_msg(const automotive_navigation_msgs::ModuleStateConstPtr& msg, const ros::Time& current_time)
 {
 	static std::string controller_tag{"veh_controller"};
-    if(!msg->name.compare(controller_tag))
+        if(msg->name.length() >= controller_tag.length() 
+		&& (0 == msg->name.compare (msg->name.length() - controller_tag.length(), controller_tag.length(), controller_tag)))
 	{
-        last_vehicle_status_time_ = current_time;
-		latest_ssc_status_ = msg->state;
+            last_vehicle_status_time_ = current_time;
+            latest_ssc_status_ = msg->state;
 	}
 }
 

--- a/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
+++ b/ssc_interface_wrapper/src/ssc_interface_wrapper_worker.cpp
@@ -22,7 +22,7 @@ uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_ti
     {
         return cav_msgs::DriverStatus::OFF;
     }
-    else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || controller_fault_) {
+    else if(current_time - last_vehicle_status_time_ > ros::Duration(timeout) || !latest_ssc_status_.compare("fatal")) {
         return cav_msgs::DriverStatus::FAULT;
     }
     return cav_msgs::DriverStatus::OPERATIONAL;
@@ -30,31 +30,17 @@ uint8_t SSCInterfaceWrapperWorker::get_driver_status(const ros::Time& current_ti
 
 void SSCInterfaceWrapperWorker::on_new_status_msg(const automotive_navigation_msgs::ModuleStateConstPtr& msg, const ros::Time& current_time)
 {
-	const std::string controller_tag("veh_controller");
-	
-    if(msg->name.length() >= controller_tag.length() 
-		&& (0 == msg->name.compare (msg->name.length() - controller_tag.length(), controller_tag.length(), controller_tag)))
+	static std::string controller_tag{"veh_controller"};
+    if(!msg->name.compare(controller_tag))
 	{
         last_vehicle_status_time_ = current_time;
-		update_control_status(msg);
+		latest_ssc_status_ = msg->state;
 	}
 }
 
-void SSCInterfaceWrapperWorker::update_control_status(const automotive_navigation_msgs::ModuleStateConstPtr& msg)
+std::string SSCInterfaceWrapperWorker::get_current_ssc_state()
 {
-	if(msg->state.compare("fatal") == 0)
-	{
-		controller_fault_ = true;
-	}
-	else if (msg->state.compare("active") == 0 || msg->state.compare("engaged") == 0)
-	{
-		robotic_control_engaged_ = true;
-	}
-
-	// TODO will move the following logic into controller specific CAN driver
-	//can_bus_timeout_ = msg -> user_can_timeout || msg -> brake_can_timeout   || msg -> steering_can_timeout
-	//		                                   || msg -> vehicle_can_timeout || msg -> subsystem_can_timeout;
-	can_bus_timeout_ = true;
+	return this->latest_ssc_status_;
 }
 
 int SSCInterfaceWrapperWorker::convert_shift_state_to_J2735(const pacmod_msgs::SystemRptIntConstPtr shift_state)
@@ -76,5 +62,5 @@ int SSCInterfaceWrapperWorker::convert_shift_state_to_J2735(const pacmod_msgs::S
 
 bool SSCInterfaceWrapperWorker::is_engaged()
 {
-    return robotic_control_engaged_;
+    return !latest_ssc_status_.compare("active");
 }


### PR DESCRIPTION
1. To enable re-engage capability, this node monitors the "failure" state from SSC controller and send a sequence command when enable_robotic_control is called at manual override state.
2. Restructure some code logic to improve code readability.