### PR TITLE
Add ssc_tester node

### DIFF
--- a/ssc_tester/CMakeLists.txt
+++ b/ssc_tester/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(ssc_tester)
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+set (DEPS 
+  rospy
+  std_msgs
+  automotive_platform_msgs
+  automotive_navigation_msgs
+  pacmod_msgs
+  ssc_ds_fusion
+  ssc_interface_wrapper
+  ssc_ne_pacifica
+  ssc_pm_lexus
+  as
+)
+
+find_package(catkin REQUIRED COMPONENTS
+  ${DEPS}
+)
+
+catkin_python_setup()
+
+catkin_package(
+        CATKIN_DEPENDS ${DEPS}
+)
+
+catkin_install_python(PROGRAMS src/ssc_tester/ssc_tester_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/ssc_tester/README.md
+++ b/ssc_tester/README.md
@@ -1,0 +1,7 @@
+# ssc_tester
+
+The ssc_tester package contains nodes and scripts for performing specialized tests of the SSC and ssc_interface. 
+
+## Nodes
+
+- ssc_tester_node This python node allows the user to set speed or steering profiles for the vehicle to execute while the user maintains manual control of the steering

--- a/ssc_tester/config/params.yaml
+++ b/ssc_tester/config/params.yaml
@@ -1,0 +1,17 @@
+# Defines the ros parameters that are required by the ssc_tester node
+
+# Double: Rate at which to send commands to the ssc_interface
+# Units: Hz
+cmd_rate: 20.0
+
+# Boolean: If true then commands will loop once the speeds list is exceeded
+loop_values: false
+
+# Double List: The values for speed or steering commands to send to the ssc. The duration of each command is specified by the values_period list
+# Speed Units: m/s
+# Steer Units: deg
+values: [ 5.0, 10.0 ]
+
+# Double List: The amount of time to send each speed or steering command before sending a different command
+# Units: Seconds
+value_period: [ 4.0, 6.0 ]

--- a/ssc_tester/launch/ssc_pacmod_tester.launch
+++ b/ssc_tester/launch/ssc_pacmod_tester.launch
@@ -1,3 +1,18 @@
+<!--
+  Copyright (C) 2018-2019 LEIDOS.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+-->
 <launch>
   <arg name="vehicle_calibration_dir" default="/opt/carma/vehicle/calibration"/>
   <arg name="publish_steer_not_speed" default="false" doc="USE WITH CAUTION: If true then steering will be published instead of speed."/>

--- a/ssc_tester/launch/ssc_pacmod_tester.launch
+++ b/ssc_tester/launch/ssc_pacmod_tester.launch
@@ -1,0 +1,34 @@
+<launch>
+  <arg name="vehicle_calibration_dir" default="/opt/carma/vehicle/calibration"/>
+  <arg name="publish_steer_not_speed" default="false" doc="USE WITH CAUTION: If true then steering will be published instead of speed."/>
+  <arg name="launch_novatel" default="false" doc="If true this launch file will try to launch the novatel_gps_driver as well" />
+
+  <group if="$(arg launch_novatel)">
+    <include file="$(find novatel_gps_driver)/launch/novatel_gps_driver_eth.launch"/>
+  </group>
+
+  <group>
+
+    <!-- Remap speed or steering to fake topic to prevent level2 control -->
+    <remap unless="$(arg publish_steer_not_speed)" from="arbitrated_steering_commands" to="fake_arbitrated_steering_commands"/> 
+    <remap if="$(arg publish_steer_not_speed)" from="arbitrated_speed_commands" to="fake_arbitrated_speed_commands"/> 
+    <include file="$(find ssc_interface_wrapper)/launch/ssc_pacmod_driver.launch">
+      <arg name="pacmod_vehicle_type" default="LEXUS_RX_450H" />
+      <arg name="use_kvaser" default="false" />
+      <arg name="use_socketcan" default="true" />
+      <arg name="socketcan_device" default="can0" />
+      <arg name="ssc_param_dir" value="$(arg vehicle_calibration_dir)/ssc_pm_lexus"/>
+    </include>
+  </group>
+
+  <group>
+    <remap from="engage" to="vehicle/engage"/>
+    <node pkg="ssc_tester" name="ssc_tester" type="ssc_tester_node.py" output="screen"> 
+      <rosparam command="load" file="$(find ssc_tester)/config/params.yaml"/>
+      <param name="publish_steer_not_speed" value="$(arg publish_steer_not_speed)"/>
+    </node>
+  </group>
+
+  <node pkg="rosbag" type="record" name="rosbag_node" args="record -o /opt/carma/logs/ --lz4 -a -x '/rosout(.*)'" />
+
+</launch>

--- a/ssc_tester/package.xml
+++ b/ssc_tester/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>ssc_tester</name>
+  <version>1.0.0</version>
+  <description>Package containing helpful nodes for testing of SSC bahaviors</description>
+
+  <maintainer email="carma@todo.todo">carma</maintainer>
+  <license>Apache 2.0</license>
+  <author email="carma@todo.todo">carma</author>
+
+  <depend>roslint</depend>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>rospy</depend>
+  <depend>std_msgs</depend>
+  <depend>automotive_platform_msgs</depend>
+  <depend>automotive_navigation_msgs</depend>
+  <depend>pacmod_msgs</depend>
+  <depend>ssc_ds_fusion</depend>
+  <depend>ssc_interface_wrapper</depend>
+  <depend>ssc_ne_pacifica</depend>
+  <depend>ssc_pm_lexus</depend>
+  <depend>as</depend>
+</package>

--- a/ssc_tester/setup.py
+++ b/ssc_tester/setup.py
@@ -1,0 +1,12 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['ssc_tester'],
+    package_dir={'': 'src'},
+)
+
+setup(**setup_args)

--- a/ssc_tester/src/ssc_tester/ssc_tester_node.py
+++ b/ssc_tester/src/ssc_tester/ssc_tester_node.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python
 #
+
+#
+# Copyright (C) 2019 LEIDOS.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
 import time
 import rospy
 import threading

--- a/ssc_tester/src/ssc_tester/ssc_tester_node.py
+++ b/ssc_tester/src/ssc_tester/ssc_tester_node.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+import time
+import rospy
+import threading
+import math
+
+from std_msgs.msg import Bool
+from autoware_msgs.msg import VehicleCmd
+from automotive_platform_msgs.msg import SteerMode
+
+# SSCTesterNode
+# Reads in a yaml list which specifies a desired speed or steering profile and executes it
+class SSCTesterNode(object):
+    def __init__(self):
+        # Init nodes
+        rospy.init_node('ssc_tester')
+
+        # Params
+        self.cmd_rate = rospy.get_param('~cmd_rate')
+        self.values = rospy.get_param('~values')
+        self.value_period = rospy.get_param('~value_period')
+        self.loop_values = rospy.get_param('~loop_values')
+        self.publish_steer_not_speed = rospy.get_param('~publish_steer_not_speed')
+
+        if (self.publish_steer_not_speed):
+            print("NOTE: You are publishing STEERING commands. Do not engage unless this is intended behavior")
+        else:
+            print("NOTE: You are publishing SPEED commands. Do not engage unless this is intended behavior")
+
+        self.current_value_index = 0
+
+        # Publishers
+        self.cmd_pub = rospy.Publisher('vehicle_cmd', VehicleCmd, queue_size=10)
+        self.steer_override_pub = rospy.Publisher('steer', SteerMode, queue_size=10)
+
+        # Subscribers
+        self.engage_sub = rospy.Subscriber('engage', Bool, self.engage_cb)
+
+        self.engaged = False
+        self.engage_lock = threading.Lock()
+        
+        #Spin Rate
+        self.spin_rate = rospy.Rate(self.cmd_rate)
+
+        self.lastTime = rospy.Time.now()
+
+
+    # Function to handle engage signal
+    def engage_cb(self, engage_msg):
+        with self.engage_lock: # Lock mutex
+            self.engaged = engage_msg.data
+            if (self.engaged): 
+                print("Engaging commands")
+                self.lastTime = rospy.Time.now()
+                self.current_value_index = 0
+            else:
+                print("Disengaging commands")
+
+    def nextCmd(self):
+        # Initialize command with disengaged as default
+        current_time = rospy.Time.now()
+        cmd_msg = VehicleCmd()
+        cmd_msg.header.frame_id = 'base_link'
+        cmd_msg.header.stamp = current_time
+        cmd_msg.gear = 4
+        cmd_msg.mode = 0 # Disable automated control
+
+        target_duration = self.value_period[self.current_value_index]
+        with self.engage_lock: # Lock mutex
+            if (self.engaged):
+
+                if (rospy.rostime.Duration(target_duration) < (current_time - self.lastTime)):
+                    self.current_value_index += 1
+                    print('Commanding next value at index ' + str(self.current_value_index))
+                    self.lastTime = current_time
+
+                    if (self.current_value_index >= len(self.values)):
+                        self.current_value_index = 0
+                        print('Reached end of values list')
+
+                        if (not self.loop_values):
+                            print('Disengaging')
+                            self.engaged = False # Disengage if at end of speed list
+                            return cmd_msg
+                        else:
+                            print('Returning to start of value list')
+
+                current_value = self.values[self.current_value_index]
+
+                if (self.publish_steer_not_speed): # Publish values as steering commands
+                    cmd_msg.gear = 4
+                    cmd_msg.mode = 1
+                    cmd_msg.ctrl_cmd.steering_angle = math.radians(current_value)
+
+                else: # Publish values as speed commands
+                    cmd_msg.gear = 4
+                    cmd_msg.mode = 1
+                    cmd_msg.ctrl_cmd.linear_velocity = current_value
+                    cmd_msg.ctrl_cmd.linear_acceleration = 0.0
+
+            return cmd_msg
+
+    def spin(self):
+        while not rospy.is_shutdown():
+            self.cmd_pub.publish(self.nextCmd())
+            
+            self.spin_rate.sleep()
+
+if __name__ == '__main__':
+    try:
+        tester = SSCTesterNode()
+        tester.spin()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
This PR adds the ssc_tester package which contains a python node that can be used to execute speed or steering profiles as level 1 controls for the vehicle. This package was initially used to collect data for the vehicle model, but might be useful for other kinds of tests as well. The user specifies the profile as a list of commands which are to be sent for the specified period. When the engage signal is sent to the ssc_interface then the commands will begin sending. When the commands stop the signal will return to 0. 