### PR TITLE
Update base image version for autoware 3.4.0 component release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/autoware.ai:3.3.0
+      - image: usdotfhwastol/autoware.ai:3.4.0
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-FROM usdotfhwastol/autoware.ai:3.3.0 as deps
+FROM usdotfhwastol/autoware.ai:3.4.0 as deps
 
 # Install remaining package deps
 RUN mkdir ~/src


### PR DESCRIPTION
Updates the base image version for the autoware 3.4.0 component release which contains autoware 1.13 pre-release logic and addresses usdot-fhwa-stol/CARMAPlatform#419