### PR TITLE
Remove gear change node

### DIFF
--- a/ssc_interface_wrapper/launch/ssc_pm_cascadia_driver.launch
+++ b/ssc_interface_wrapper/launch/ssc_pm_cascadia_driver.launch
@@ -48,6 +48,7 @@
   </include>
 
   <!-- SSC -->
+
   <group>
     <remap from="brake_cmd" to="pacmod/as_rx/brake_cmd"/>
     <remap from="brake_report" to="pacmod/parsed_tx/brake_rpt"/>
@@ -59,7 +60,7 @@
     <remap from="transmission_cmd" to="pacmod/as_rx/shift_cmd"/>
     <remap from="transmission_report" to="pacmod/parsed_tx/shift_rpt"/>
     <remap from="turn_signal_cmd" to="pacmod/as_rx/turn_cmd"/>
-    <remap from="speed" to="pacmod/parsed_tx/vehicle_speed_rpt"/>
+    <remap from="vehicle_speed" to="pacmod/parsed_tx/vehicle_speed_rpt"/>
     <remap from="wheel_speed" to="pacmod/parsed_tx/wheel_speed_rpt"/>
     <remap from="global_report" to="pacmod/parsed_tx/global_rpt"/>
     <include file="$(find ssc_interface_wrapper)/launch/carma_speed_steering_control.launch">
@@ -70,9 +71,8 @@
 
   <!-- SSC Interface Using custom remapping for gear change node -->
   <group>
-    <remap from="as/arbitrated_speed_commands" to="ssc_interface/arbitrated_speed_commands"/> <!-- Gear change required remapping -->
-    <remap from="as/arbitrated_steering_commands" to="ssc_interface/arbitrated_steering_commands"/> <!-- Gear change required remapping -->
-
+    <remap from="as/arbitrated_speed_commands" to="arbitrated_speed_commands"/>
+    <remap from="as/arbitrated_steering_commands" to="arbitrated_steering_commands"/>
     <remap from="as/brake_feedback" to="brake_feedback"/>
     <remap from="as/steering_feedback" to="steering_feedback"/>
     <remap from="as/curvature_feedback" to="curvature_feedback"/>
@@ -94,12 +94,4 @@
         <arg name="loop_rate" value="30.0"/>
     </include>
   </group>
-
-  <!-- SCC Gear Change Node -->
-  <node pkg="ssc_gear_change" type="gear_change" name="gear_change">
-		<param name="delay_time" value="3" />
-		<remap from="as/arbitrated_speed_commands" to="arbitrated_speed_commands"/>
-		<remap from="as/gear_select" to="gear_select"/>
-		<remap from="as/gear_feedback" to="gear_feedback"/>
-  </node>
 </launch>


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
The most recent version of the SSC for the red truck contains the same functionality as the gear_change node. Therefore the gear_change node can be removed. Doing so also resolves the SSC module states not reflecting the current status properly. 
## Related Issue
Resolves usdot-fhwa-stol/CARMAPlatform#497
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.