### PR TITLE
Merge checkout.sh build failure fix into develop

### DIFF
--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -27,4 +27,4 @@ fi
 git clone https://github.com/usdot-fhwa-stol/CARMAMsgs.git ${dir}/src/CARMAMsgs --branch develop --depth 1
 git clone https://github.com/usdot-fhwa-stol/CARMAUtils.git ${dir}/src/CARMAUtils --branch develop --depth 1
 # Required to build the dbw_pacifica_msgs message set.
-git clone https://github.com/jtbaird/pacifica-dbw-ros.git ${dir}/src/pacifica-dbw-ros --branch master --depth 1
+git clone https://github.com/NewEagleRaptor/pacifica-dbw-ros.git ${dir}/src/pacifica-dbw-ros --branch master --depth 1


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
NewEagleRaptor has approved our PR, and now we can return to cloning their repo for SscInterfaceWrapper, rather than using the jtbaird fork.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Missing value in NewEagleRaptor/pacifica-dbw-ros/pacifica-dbw/package.xml was causing SSC interface wrapper builds to fail. Temp fix was to fork their repo, make the fix, do a PR back to NewEagleRaptor, and use the fork in the meantime. PR to NewEagleRaptor has been approved and merged, so now we can go back to using their repo.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.